### PR TITLE
Archivos de backend de herramientas y vehículos + inicio del frontend de herramientas

### DIFF
--- a/lib/backend/controllers/herramientas/get_herramientas.dart
+++ b/lib/backend/controllers/herramientas/get_herramientas.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:sistema_acviis/models/herramienta.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+// Función para obtener todas las herramientas
+Future<List<Herramienta>> fetchHerramientasFromApi() async {
+  final response = await http.get(Uri.parse('http://localhost:3000/herramientas'));
+  if (response.statusCode == 200) {
+    final List<dynamic> data = jsonDecode(response.body);
+    return data.map((e) => Herramienta.fromJson(e)).toList();
+  } else {
+    throw Exception('Error al obtener herramientas');
+  }
+}
+
+// Función para obtener una herramienta por id
+Future<Herramienta> fetchHerramientaFromApi(String id) async {
+  final response = await http.get(Uri.parse('http://localhost:3000/herramientas/$id'));
+  if (response.statusCode == 200) {
+    final Map<String, dynamic> herramienta = jsonDecode(response.body);
+    return Herramienta.fromJson(herramienta);
+  } else {
+    debugPrint('Error al obtener herramienta de id: $id: ${response.statusCode} - ${response.reasonPhrase}');
+    throw Exception('Error al obtener herramienta');
+  }
+}

--- a/lib/backend/index.js
+++ b/lib/backend/index.js
@@ -27,6 +27,7 @@ const contratosMongoRoutes = require('./routes/contratos/c_mongoDB');
 const anexosSupabaseRoutes = require('./routes/anexos/a_supabase');
 const anexosMongoRoutes = require('./routes/anexos/a_mongoDB');
 const comentariosRouter = require('./routes/comentarios');
+const herramientasRoutes = require('./routes/herramientas');
 
 // Usar rutas
 app.use('/trabajadores', trabajadoresRoutes); // /trabajadores y /trabajadores/:id
@@ -39,6 +40,8 @@ app.use('/anexos/supabase', anexosSupabaseRoutes);
 app.use('/anexos/mongo', anexosMongoRoutes);
 
 app.use('/comentarios', comentariosRouter); // /comentarios y /comentarios/:id
+
+app.use('/herramientas', herramientasRoutes);
 
 // --------- INICIAR SERVIDOR ---------
 app.listen(port, () => {

--- a/lib/backend/index.js
+++ b/lib/backend/index.js
@@ -28,6 +28,7 @@ const anexosSupabaseRoutes = require('./routes/anexos/a_supabase');
 const anexosMongoRoutes = require('./routes/anexos/a_mongoDB');
 const comentariosRouter = require('./routes/comentarios');
 const herramientasRoutes = require('./routes/herramientas');
+const vehiculosRoutes = require('./routes/vehiculos');
 
 // Usar rutas
 app.use('/trabajadores', trabajadoresRoutes); // /trabajadores y /trabajadores/:id
@@ -42,6 +43,7 @@ app.use('/anexos/mongo', anexosMongoRoutes);
 app.use('/comentarios', comentariosRouter); // /comentarios y /comentarios/:id
 
 app.use('/herramientas', herramientasRoutes);
+app.use('/vehiculos', vehiculosRoutes);
 
 // --------- INICIAR SERVIDOR ---------
 app.listen(port, () => {

--- a/lib/backend/prisma/schema.prisma
+++ b/lib/backend/prisma/schema.prisma
@@ -86,7 +86,7 @@ model herramientas {
   estado      String    @db.VarChar
   garantia    DateTime? @db.Date
   cantidad    Int       @db.SmallInt
-  obra_asig   String?   @db.VarChar // Cuando hagamos todo el tema de las obras, este campo debería ser una FK a la obra.
+  obra_asig   String?   @db.VarChar
   asig_inicio DateTime? @db.Date
   asig_fin    DateTime? @db.Date
 }
@@ -104,4 +104,5 @@ model vehiculos {
   neumaticos        String   @db.VarChar
   rueda_repuesto    Boolean
   observaciones     String?  @db.VarChar
+  estado            String   @db.VarChar
 }

--- a/lib/backend/prisma/schema.prisma
+++ b/lib/backend/prisma/schema.prisma
@@ -3,71 +3,105 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
-// backend/prisma/schema.prisma
-
 model trabajadores {
-  id                        String    @id @default(uuid())
-  nombre_completo           String    @unique
-  estado_civil              String
-  rut                       String    @unique
-  fecha_de_nacimiento       DateTime
-  direccion                 String
-  correo_electronico        String    @unique
-  sistema_de_salud          String
-  prevision_afp             String
-  obra_en_la_que_trabaja    String
-  rol_que_asume_en_la_obra  String
-  estado                    String
-  contratos   contratos[]
-  comentarios comentarios[]
+  id                       String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  nombre_completo          String        @unique @db.VarChar
+  estado_civil             String        @db.VarChar
+  rut                      String        @unique @db.VarChar
+  fecha_de_nacimiento      DateTime      @db.Date
+  direccion                String        @db.VarChar
+  correo_electronico       String        @unique @db.VarChar
+  sistema_de_salud         String        @db.VarChar
+  prevision_afp            String        @db.VarChar
+  obra_en_la_que_trabaja   String        @db.VarChar
+  rol_que_asume_en_la_obra String        @db.VarChar
+  estado                   String        @db.VarChar
+  comentarios              comentarios[]
+  contratos                contratos[]
 }
 
 model contratos {
-  id                     String        @id @default(uuid())
-  id_trabajadores        String        @db.Uuid
-  plazo_de_contrato      String
-  estado                 String
-  fecha_de_contratacion  DateTime
+  id                    String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id_trabajadores       String        @db.Uuid
+  plazo_de_contrato     String        @db.VarChar
+  estado                String        @db.VarChar
+  fecha_de_contratacion DateTime      @db.Date
+  anexos                anexos[]
+  comentarios           comentarios[]
+  trabajadores          trabajadores  @relation(fields: [id_trabajadores], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_contrato_trabajador")
 
-  trabajadores trabajadores @relation(fields: [id_trabajadores], references: [id])
-  anexos anexos[]
-  comentarios comentarios[]
-
-  @@index([id_trabajadores])
+  @@index([id_trabajadores], map: "idx_contratos_id_trabajadores")
 }
 
 model anexos {
-  id                    String        @id @default(uuid())
-  id_contrato           String        @db.Uuid
-  fecha_de_creacion     DateTime
-  duracion              String
-  tipo                  String
-  parametros            String
-  
-  comentarios comentarios[]
-  contratos contratos @relation(fields: [id_contrato], references: [id])
+  id                String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id_contrato       String        @db.Uuid
+  fecha_de_creacion DateTime      @db.Date
+  duracion          String        @db.VarChar
+  tipo              String        @db.VarChar
+  parametros        String        @default("") @db.VarChar
+  contratos         contratos     @relation(fields: [id_contrato], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_anexo_contrato")
+  comentarios       comentarios[]
 
-
-  @@index([id_contrato])
+  @@index([id_contrato], map: "idx_anexos_id_contrato")
 }
 
 model comentarios {
-  id              String      @id @default(uuid())
-  id_trabajadores String      @db.Uuid
-  id_contrato     String?     @db.Uuid
-  id_anexo        String?     @db.Uuid
-  fecha           DateTime
-  comentario      String
+  id              String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  id_trabajadores String       @db.Uuid
+  id_contrato     String?      @db.Uuid
+  fecha           DateTime     @db.Timestamp(6)
+  comentario      String       @db.VarChar
+  id_anexo        String?      @db.Uuid
+  anexo           anexos?      @relation(fields: [id_anexo], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_comentario_anexo")
+  contrato        contratos?   @relation(fields: [id_contrato], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_comentario_contrato")
+  trabajadores    trabajadores @relation(fields: [id_trabajadores], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fk_comentario_trabajador")
 
-  trabajadores    trabajadores @relation(fields: [id_trabajadores], references: [id])
-  contrato        contratos?   @relation(fields: [id_contrato], references: [id])
-  anexo           anexos?      @relation(fields: [id_anexo], references: [id])
+  @@index([id_anexo], map: "idx_comentarios_id_anexo")
+  @@index([id_contrato], map: "idx_comentarios_id_contrato")
+  @@index([id_trabajadores], map: "idx_comentarios_id_trabajadores")
+}
 
-  @@index([id_trabajadores])
-  @@index([id_contrato])
-  @@index([id_anexo])
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model proveedores {
+  id                 String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  nombre             String    @db.VarChar
+  rut                String    @unique @db.VarChar
+  direccion          String?   @db.VarChar
+  correo_electronico String?   @db.VarChar
+  telefono           String?   @db.VarChar
+  estado             String?   @default("\"Activo\" para proveedores disponibles, \"Inactivo\" para proveedores no disponibles.") @db.VarChar
+  fecha_registro     DateTime? @db.Date
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model herramientas {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  tipo        String    @db.VarChar
+  estado      String    @db.VarChar
+  garantia    DateTime? @db.Date
+  cantidad    Int       @db.SmallInt
+  obra_asig   String?   @db.VarChar
+  asig_inicio DateTime? @db.Date
+  asig_fin    DateTime? @db.Date
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model vehiculos {
+  id                String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  patente           String   @unique @db.VarChar
+  permiso_circ      String   @db.VarChar
+  revision_tecnica  DateTime @db.Date
+  revision_gases    DateTime @db.Date
+  ultima_mantencion DateTime @db.Date
+  descripcion_mant  String?  @db.VarChar
+  capacidad_kg      Int
+  neumaticos        String   @db.VarChar
+  rueda_repuesto    Boolean
+  observaciones     String?  @db.VarChar
 }

--- a/lib/backend/prisma/schema.prisma
+++ b/lib/backend/prisma/schema.prisma
@@ -86,7 +86,7 @@ model herramientas {
   estado      String    @db.VarChar
   garantia    DateTime? @db.Date
   cantidad    Int       @db.SmallInt
-  obra_asig   String?   @db.VarChar
+  obra_asig   String?   @db.VarChar // Cuando hagamos todo el tema de las obras, este campo debería ser una FK a la obra.
   asig_inicio DateTime? @db.Date
   asig_fin    DateTime? @db.Date
 }

--- a/lib/backend/routes/herramientas.js
+++ b/lib/backend/routes/herramientas.js
@@ -1,0 +1,149 @@
+const express = require('express');
+const router = express.Router();
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+router.get('/', async (req, res) => {
+  try {
+    const herramientas = await prisma.herramientas.findMany({
+      orderBy: { id: 'desc' },
+      select: {
+        id: true,
+        tipo: true,
+        estado: true,
+        garantia: true,
+        cantidad: true,
+        obra_asig: true,
+        asig_inicio: true,
+        asig_fin: true,
+      },
+    });
+    res.json(herramientas);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error al obtener herramientas' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  const id = req.params.id;
+  const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!uuidV4Regex.test(id)) {
+    return res.status(400).json({ error: 'ID de herramienta inválido (no es UUID v4)' });
+  }
+  try {
+    const herramienta = await prisma.herramientas.findUnique({ 
+      where: { id },
+    });
+    if (!herramienta) return res.status(404).json({ error: 'Herramienta no encontrado' });
+    res.json(herramienta);
+  } catch (err) {
+    console.error(`Error al buscar herramienta con id ${id}:`, err);
+    res.status(500).json({
+      error: `No se pudo obtener la herramienta con id: ${id}`,
+      details: err instanceof Error ? err.message : String(err)
+    });
+  }
+});
+
+
+router.post('/', async (req, res) => {
+  const {
+    id,
+    tipo,
+    estado,
+    garantia,
+    cantidad,
+    obra_asig,
+    asig_inicio,
+    asig_fin,
+  } = req.body;
+
+  if (!tipo || !estado || !cantidad) {
+    return res.status(400).json({ error: 'Es necesario rellenar los campos requeridos.' });
+  }
+
+  try {
+    const nuevo = await prisma.herramientas.create({
+      data: {
+        id,
+        tipo,
+        estado,
+        garantia: garantia ? new Date(garantia) : null,
+        cantidad,
+        obra_asig,
+        asig_inicio: asig_inicio ? new Date(asig_inicio) : null,
+        asig_fin: asig_fin ? new Date(asig_fin) : null,
+      },
+    });
+    res.status(201).json(nuevo);
+  } catch (error) {
+    res.status(500).json({ error: 'No se pudo crear registro de herramienta', details: error.message });
+  }
+});
+
+router.put('/:id/datos', async (req, res) => {
+  const { id } = req.params;
+  const {
+    tipo,
+    estado,
+    garantia,
+    cantidad,
+    obra_asig,
+    asig_inicio,
+    asig_fin,
+  } = req.body;
+  if (
+    !tipo || !estado ||
+    !garantia || !cantidad || !obra_asig ||
+    !asig_inicio || !asig_fin
+  ) {
+    return res.status(400).json({ error: 'Todos los campos son obligatorios' });
+  }
+
+  try {
+    const actualizado = await prisma.herramientas.update({
+      where: { id },
+      data: {
+        tipo,
+        estado,
+        garantia,
+        cantidad,
+        obra_asig,
+        asig_inicio,
+        asig_fin,
+      },
+    });
+    res.json(actualizado);
+  } catch (error) {
+    res.status(500).json({ error: 'No se pudo actualizar la herramienta', details: error.message });
+  }
+});
+
+
+// 'Eliminar' una herramienta.
+router.put('/:id/dar-de-baja', async (req, res) => {
+    const { id } = req.params;
+
+    try {
+        const herramientaActualizada = await prisma.herramientas.update({
+            where: { id },
+            data: {
+                estado: 'de baja',
+                cantidad: 0,
+            }
+        });
+
+        res.status(200).json({
+            mensaje: 'Herramienta dada de baja correctamente',
+            herramienta: herramientaActualizada
+        });
+
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Error al dar de baja la herramienta' });
+    }
+});
+
+
+module.exports = router;

--- a/lib/backend/routes/herramientas.js
+++ b/lib/backend/routes/herramientas.js
@@ -35,7 +35,7 @@ router.get('/:id', async (req, res) => {
     const herramienta = await prisma.herramientas.findUnique({ 
       where: { id },
     });
-    if (!herramienta) return res.status(404).json({ error: 'Herramienta no encontrado' });
+    if (!herramienta) return res.status(404).json({ error: 'Herramienta no encontrada' });
     res.json(herramienta);
   } catch (err) {
     console.error(`Error al buscar herramienta con id ${id}:`, err);
@@ -49,9 +49,7 @@ router.get('/:id', async (req, res) => {
 
 router.post('/', async (req, res) => {
   const {
-    id,
     tipo,
-    estado,
     garantia,
     cantidad,
     obra_asig,
@@ -59,16 +57,15 @@ router.post('/', async (req, res) => {
     asig_fin,
   } = req.body;
 
-  if (!tipo || !estado || !cantidad) {
+  if (!tipo || !cantidad) {
     return res.status(400).json({ error: 'Es necesario rellenar los campos requeridos.' });
   }
 
   try {
     const nuevo = await prisma.herramientas.create({
       data: {
-        id,
         tipo,
-        estado,
+        estado: "Activo",
         garantia: garantia ? new Date(garantia) : null,
         cantidad,
         obra_asig,
@@ -86,19 +83,18 @@ router.put('/:id/datos', async (req, res) => {
   const { id } = req.params;
   const {
     tipo,
-    estado,
     garantia,
     cantidad,
     obra_asig,
     asig_inicio,
     asig_fin,
   } = req.body;
-  if (
-    !tipo || !estado ||
-    !garantia || !cantidad || !obra_asig ||
-    !asig_inicio || !asig_fin
-  ) {
-    return res.status(400).json({ error: 'Todos los campos son obligatorios' });
+
+  const requiredFields = ["tipo", "garantia", "cantidad", "obra_asig", "asig_inicio", "asig_fin"];
+  for (const field of requiredFields) {
+    if (req.body[field] === undefined || req.body[field] === null) {
+      return res.status(400).json({ error: `El campo "${field}" es obligatorio.` });
+    }
   }
 
   try {
@@ -106,7 +102,6 @@ router.put('/:id/datos', async (req, res) => {
       where: { id },
       data: {
         tipo,
-        estado,
         garantia,
         cantidad,
         obra_asig,
@@ -129,7 +124,7 @@ router.put('/:id/dar-de-baja', async (req, res) => {
         const herramientaActualizada = await prisma.herramientas.update({
             where: { id },
             data: {
-                estado: 'de baja',
+                estado: 'De baja',
                 cantidad: 0,
             }
         });

--- a/lib/backend/routes/vehiculos.js
+++ b/lib/backend/routes/vehiculos.js
@@ -1,0 +1,184 @@
+const express = require('express');
+const router = express.Router();
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+router.get('/', async (req, res) => {
+  try {
+    const vehiculos = await prisma.vehiculos.findMany({
+      orderBy: { id: 'desc' },
+      select: {
+        id: true,
+        patente: true,
+        permiso_circ: true,
+        revision_tecnica: true,
+        revision_gases: true,
+        ultima_mantencion: true,
+        descripcion_mant: true,
+        capacidad_kg: true,
+        neumaticos: true,
+        rueda_repuesto: true,
+        observaciones: true,
+      },
+    });
+    res.json(vehiculos);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error al obtener vehículos' });
+  }
+});
+
+
+router.get('/:id', async (req, res) => {
+  const id = req.params.id;
+  const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!uuidV4Regex.test(id)) {
+    return res.status(400).json({ error: 'ID de vehículo inválido (no es UUID v4)' });
+  }
+  try {
+    const vehiculo = await prisma.vehiculos.findUnique({ 
+      where: { id },
+    });
+    if (!vehiculo) return res.status(404).json({ error: 'Vehículo no encontrado' });
+    res.json(vehiculo);
+  } catch (err) {
+    console.error(`Error al buscar vehículo con id ${id}:`, err);
+    res.status(500).json({
+      error: `No se pudo obtener el vehículo con id: ${id}`,
+      details: err instanceof Error ? err.message : String(err)
+    });
+  }
+});
+
+
+router.post('/', async (req, res) => {
+  const {
+    patente,
+    permiso_circ,
+    revision_tecnica,
+    revision_gases,
+    ultima_mantencion,
+    descripcion_mant,
+    capacidad_kg,
+    neumaticos,
+    rueda_repuesto,
+    observaciones,
+  } = req.body;
+
+  const requiredFields = [
+    "patente",
+    "permiso_circ",
+    "revision_tecnica",
+    "revision_gases",
+    "ultima_mantencion",
+    "capacidad_kg",
+    "neumaticos",
+    "rueda_repuesto"
+  ];
+
+  for (const field of requiredFields) {
+    if (req.body[field] === undefined || req.body[field] === null) {
+        return res.status(400).json({ error: `El campo ${field} es obligatorio.` });
+    }
+  }
+
+  try {
+    const nuevo = await prisma.vehiculos.create({
+      data: {
+        patente,
+        permiso_circ,
+        revision_tecnica: revision_tecnica ? new Date(revision_tecnica) : null,
+        revision_gases: revision_gases ? new Date(revision_gases) : null,
+        ultima_mantencion: ultima_mantencion ? new Date(ultima_mantencion) : null,
+        descripcion_mant,
+        capacidad_kg,
+        neumaticos,
+        rueda_repuesto,
+        observaciones,
+        estado: "Activo",
+      },
+    });
+    res.status(201).json(nuevo);
+  } catch (error) {
+    res.status(500).json({ error: 'No se pudo crear registro de vehículo', details: error.message });
+  }
+});
+
+
+router.put('/:id/datos', async (req, res) => {
+  const { id } = req.params;
+  const {
+    patente,
+    permiso_circ,
+    revision_tecnica,
+    revision_gases,
+    ultima_mantencion,
+    descripcion_mant,
+    capacidad_kg,
+    neumaticos,
+    rueda_repuesto,
+    observaciones,
+  } = req.body;
+
+  const requiredFields = [
+    "patente",
+    "permiso_circ",
+    "revision_tecnica",
+    "revision_gases",
+    "ultima_mantencion",
+    "capacidad_kg",
+    "neumaticos",
+    "rueda_repuesto"
+  ];
+  for (const field of requiredFields) {
+    if (req.body[field] === undefined || req.body[field] === null) {
+    return res.status(400).json({ error: `El campo "${field}" es obligatorio.` });
+    }   
+  }
+
+  try {
+    const actualizado = await prisma.vehiculos.update({
+      where: { id },
+      data: {
+        patente,
+        permiso_circ,
+        revision_tecnica,
+        revision_gases,
+        ultima_mantencion,
+        capacidad_kg,
+        descripcion_mant,
+        neumaticos,
+        rueda_repuesto,
+        observaciones,
+      },
+    });
+    res.json(actualizado);
+  } catch (error) {
+    res.status(500).json({ error: 'No se pudo actualizar el vehículo', details: error.message });
+  }
+});
+
+
+router.put('/:id/dar-de-baja', async (req, res) => {
+    const { id } = req.params;
+
+    try {
+        const vehiculoActualizado = await prisma.vehiculos.update({
+            where: { id },
+            data: {
+                estado: 'De baja',
+            }
+        });
+
+        res.status(200).json({
+            mensaje: 'Vehículo dada de baja correctamente',
+            vehiculo: vehiculoActualizado
+        });
+
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Error al dar de baja el vehículo' });
+    }
+});
+
+module.exports = router;

--- a/lib/frontend/utils/constants/routes.dart
+++ b/lib/frontend/utils/constants/routes.dart
@@ -7,6 +7,7 @@ import 'package:sistema_acviis/frontend/views/trabajadores/eliminar_trabajadores
 import 'package:sistema_acviis/frontend/views/trabajadores/modificar_trabajadores_view.dart';
 import 'package:sistema_acviis/frontend/views/trabajadores/trabajadores_view.dart';
 import 'package:sistema_acviis/frontend/views/trabajadores/eliminar_contratos_view.dart';
+import 'package:sistema_acviis/frontend/views/logistica/herramientas_view.dart';
 /*
   Aqui se importaran todas las vistas presentes en el sistema
   (Para el primer incremento serian todas las vistas asociadas
@@ -33,5 +34,6 @@ final Map<String, WidgetBuilder> routes = {
   '/home_page/trabajadores_view/modificar_trabajadores_view' : (BuildContext context) {
     final args = ModalRoute.of(context)!.settings.arguments as List<dynamic>;
     return ModificarTrabajadoresView(trabajadores: args);
-  }
+  },
+  '/home_page/herramientas_view' : (BuildContext context) => HerramientasView(),
 };

--- a/lib/frontend/views/home_page.dart
+++ b/lib/frontend/views/home_page.dart
@@ -45,7 +45,8 @@ class _HomePageState extends State<HomePage> {
           {
             'title': 'Obras',
             'description': 'Funciones de obras: Crear, Charlas, Asistencia, etc',
-            'icon': Icon(Icons.construction, color: AppColors.primaryDarker)
+            'icon': Icon(Icons.construction, color: AppColors.primaryDarker),
+            'screen': '/home_page/herramientas_view'
           },
           {
             'title': 'Opciones',

--- a/lib/frontend/views/logistica/func/lista_herramientas.dart
+++ b/lib/frontend/views/logistica/func/lista_herramientas.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:sistema_acviis/frontend/utils/constants/constants.dart';
+import 'package:sistema_acviis/frontend/widgets/checkbox.dart';
+import 'package:sistema_acviis/frontend/widgets/expansion_tile_herramienta.dart';
+import 'package:sistema_acviis/providers/custom_checkbox_provider.dart';
+import 'package:sistema_acviis/providers/herramientas_provider.dart';
+
+class ListaHerramientas extends StatefulWidget {
+  const ListaHerramientas({super.key});
+
+  @override
+  State<ListaHerramientas> createState() => _ListaHerramientasState();
+}
+
+class _ListaHerramientasState extends State<ListaHerramientas> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final herramientasProvider = Provider.of<HerramientasProvider>(context, listen: false);
+      herramientasProvider.fetchHerramientas().then((_) {
+        if (!mounted) return; // <-- Agregado
+        Provider.of<CheckboxProvider>(context, listen: false)
+            .setCheckBoxes(herramientasProvider.herramientas.length);
+      });
+    });
+  }
+
+  Widget build(BuildContext context) {
+    final provider = context.watch<HerramientasProvider>();
+    final checkboxProvider = context.watch<CheckboxProvider>();
+
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (checkboxProvider.checkBoxes.length != provider.herramientas.length + 1) {
+      checkboxProvider.setCheckBoxes(provider.herramientas.length);
+    }
+    });
+
+    if (provider.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (provider.herramientas.isEmpty) {
+      return const Center(child: Text('No hay herramientas para mostrar.'));
+    }
+    if (checkboxProvider.checkBoxes.length != (provider.herramientas.length + 1)) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final double tableWidth = MediaQuery.of(context).size.width > 600
+        ? MediaQuery.of(context).size.width
+        : 600;
+
+    return Expanded(
+      child: SingleChildScrollView(
+        scrollDirection: Axis.vertical,
+        child: SizedBox(
+          width: tableWidth - normalPadding * 2,
+          child: Column(
+            children: [
+              Row(
+                children: [
+                  Flexible(
+                    flex: 0,
+                    fit: FlexFit.tight,
+                    child: PrimaryCheckbox(customCheckbox: checkboxProvider.checkBoxes[0])),
+                  Expanded(
+                    flex: 2,
+                    child: Center(
+                      child: Text(
+                      'Lista de Trabajadores Registrados',
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                      ),
+                    ),
+                  ),
+                  Flexible(
+                    flex: 0,
+                    fit: FlexFit.tight,
+                    child: Align(
+                      alignment: Alignment.centerRight,
+                      child: Text('Opciones', style: TextStyle(fontWeight: FontWeight.bold)),
+                    ),
+                  ),
+                ],
+              ),
+
+              const Divider(),
+              ...List.generate(provider.herramientas.length, (i) {
+                final herramienta = provider.herramientas[i];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 1.0),
+                  child: Row(
+                    children: [
+                      PrimaryCheckbox(customCheckbox: checkboxProvider.checkBoxes[i + 1]),
+                      Expanded(
+                        child: ExpansionTileHerramienta(
+                          herramienta: herramienta,                        
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/frontend/views/logistica/func/search_bar.dart
+++ b/lib/frontend/views/logistica/func/search_bar.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:sistema_acviis/frontend/utils/constants/constants.dart';
+
+
+class HerramientasSearchBar extends StatefulWidget {
+  const HerramientasSearchBar({
+    super.key
+  });
+
+  @override
+  State<HerramientasSearchBar> createState() => _HerramientasSearchBarState();
+}
+
+class _HerramientasSearchBarState extends State<HerramientasSearchBar> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // final provider = Provider.of<HerramientasProvider>(context, listen: false);
+
+    return SizedBox(
+      height: normalPadding * 2.5,
+      child: TextField(
+        controller: _controller,
+        decoration: InputDecoration(
+          prefixIcon: const Icon(Icons.search),
+          hintText: 'Buscar herramienta por nombre...',
+          contentPadding: EdgeInsets.symmetric(horizontal: normalPadding),
+          border: const OutlineInputBorder(),
+        ),
+        onChanged: (value) {
+          // provider.actualizarBusqueda(value);
+        },
+      ),
+    );
+  }
+}

--- a/lib/frontend/views/logistica/herramientas_view.dart
+++ b/lib/frontend/views/logistica/herramientas_view.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:sistema_acviis/providers/herramientas_provider.dart';
+import 'package:sistema_acviis/frontend/utils/constants/constants.dart';
+import 'package:sistema_acviis/frontend/views/logistica/func/lista_herramientas.dart';
+import 'package:sistema_acviis/frontend/views/logistica/func/search_bar.dart';
+import 'package:sistema_acviis/frontend/widgets/buttons.dart';
+import 'package:sistema_acviis/frontend/widgets/scaffold.dart';
+
+class HerramientasView extends StatefulWidget {
+  const HerramientasView({super.key});
+
+  @override
+  State<HerramientasView> createState() => _HerramientasViewState();
+}
+
+class _HerramientasViewState extends State<HerramientasView> {
+  @override
+  Widget build(BuildContext context) {  
+    return PrimaryScaffold(
+      title: 'Herrmamientas',
+      body: Column(
+        children: [
+          Row(
+            children: [
+              CascadeButton(
+                title: 'Acciones/Métodos',
+                startRight: true, offset: 0.0,
+                icon: Icon(Icons.menu),
+                children: [
+                  PrimaryButton(
+                    text: 'Agregar herramienta',
+                    onPressed: () {}
+                  ),
+
+                  SizedBox(height: normalPadding,),
+
+                  PrimaryButton(
+                    text: 'Modificar herramientas',
+                    onPressed: () {}
+                  ),
+
+                  SizedBox(height: normalPadding,),
+
+                  PrimaryButton(
+                    text: 'Eliminar herramientas',
+                    onPressed: () {}
+                  ),
+                ]
+              ),
+
+              SizedBox(width: normalPadding,),
+
+              Expanded(
+                child: HerramientasSearchBar(),
+              ),  
+
+              SizedBox(width: normalPadding,),
+
+              CascadeButton(
+                title: 'Filtros Herramientas',
+                offset: 0.0,
+                icon: Icon(Icons.filter_alt_sharp),
+                children: [],
+              ),
+            ],
+          ),
+
+          SizedBox(height: normalPadding,),
+
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: normalPadding),
+            child: ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: Container(
+              height: 10,
+              color: Colors.black,
+            ),
+            ),
+          ),
+          ListaHerramientas()
+        ],
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/expansion_tile_herramienta.dart
+++ b/lib/frontend/widgets/expansion_tile_herramienta.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:sistema_acviis/models/herramienta.dart';
+
+class ExpansionTileHerramienta extends StatelessWidget {
+  final Herramienta herramienta;
+
+  const ExpansionTileHerramienta({Key? key, required this.herramienta}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      title: Text(herramienta.tipo),
+      subtitle: Text('Estado: ${herramienta.estado}'),
+      children: [
+        ListTile(
+          title: Text('Garantía'),
+          subtitle: Text(herramienta.garantia != null ? herramienta.garantia!.toLocal().toString().split(' ')[0] : 'Sin garantía'),
+        ),
+        ListTile(
+          title: Text('Cantidad'),
+          subtitle: Text(herramienta.cantidad.toString()),
+        ),
+        ListTile(
+          title: Text('Obra asignada'),
+          subtitle: Text(herramienta.obraAsig ?? 'Sin asignar'),
+        ),
+        ListTile(
+          title: Text('Asignación inicio'),
+          subtitle: Text(herramienta.asigInicio != null ? herramienta.asigInicio!.toLocal().toString().split(' ')[0] : 'No asignada'),
+        ),
+        ListTile(
+          title: Text('Asignación fin'),
+          subtitle: Text(herramienta.asigFin != null ? herramienta.asigFin!.toLocal().toString().split(' ')[0] : 'No asignada'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:sistema_acviis/providers/custom_checkbox_provider.dart';
 import 'package:sistema_acviis/frontend/views/home_page.dart';
 import 'package:sistema_acviis/frontend/utils/constants/routes.dart';
 import 'package:provider/provider.dart';
+import 'package:sistema_acviis/providers/herramientas_provider.dart';
 import 'package:sistema_acviis/providers/trabajadores_provider.dart';
 import 'package:sistema_acviis/providers/contratos_provider.dart';
 import 'package:sistema_acviis/providers/comentarios_provider.dart';
@@ -16,6 +17,7 @@ void main() {
         ChangeNotifierProvider(create: (_) => ContratosProvider()),
         ChangeNotifierProvider(create: (_) => CheckboxProvider()),
         ChangeNotifierProvider(create: (_) => ComentariosProvider()),
+        ChangeNotifierProvider(create: (_) => HerramientasProvider()),
       ],
       child: MainApp(),
     ),

--- a/lib/models/herramienta.dart
+++ b/lib/models/herramienta.dart
@@ -1,0 +1,47 @@
+class Herramienta {
+  final String id;
+  final String tipo;
+  final String estado;
+  final DateTime? garantia;
+  final int cantidad;
+  final String? obraAsig;
+  final DateTime? asigInicio;
+  final DateTime? asigFin;
+
+  Herramienta({
+    required this.id,
+    required this.tipo,
+    required this.estado,
+    this.garantia,
+    required this.cantidad,
+    this.obraAsig,
+    this.asigInicio,
+    this.asigFin,
+  });
+
+  factory Herramienta.fromJson(Map<String, dynamic> json) {
+    return Herramienta(
+      id: json['id'],
+      tipo: json['tipo'],
+      estado: json['estado'],
+      garantia: json['garantia'] != null ? DateTime.parse(json['garantia']) : null,
+      cantidad: json['cantidad'],
+      obraAsig: json['obra_asig'],
+      asigInicio: json['asig_inicio'] != null ? DateTime.parse(json['asig_inicio']) : null,
+      asigFin: json['asig_fin'] != null ? DateTime.parse(json['asig_fin']) : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'tipo': tipo,
+      'estado': estado,
+      'garantia': garantia?.toIso8601String(),
+      'cantidad': cantidad,
+      'obra_asig': obraAsig,
+      'asig_inicio': asigInicio?.toIso8601String(),
+      'asig_fin': asigFin?.toIso8601String(),
+    };
+  }
+}

--- a/lib/providers/herramientas_provider.dart
+++ b/lib/providers/herramientas_provider.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:sistema_acviis/models/herramienta.dart';
+import 'package:sistema_acviis/backend/controllers/herramientas/get_herramientas.dart';
+
+class HerramientasProvider extends ChangeNotifier {
+  List<Herramienta> _herramientas = [];
+  List<Herramienta> get herramientas => _herramientas;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  Future<void> fetchHerramientas() async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      _herramientas = await fetchHerramientasFromApi();
+    } catch (e) {
+      // Manejo de error
+      _herramientas = [];
+    }
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  // Filtros
+  List<Herramienta> filterByTipo(String tipo) =>
+      _herramientas.where((h) => h.tipo == tipo).toList();
+
+  List<Herramienta> filterByEstado(String estado) =>
+      _herramientas.where((h) => h.estado == estado).toList();
+
+  List<Herramienta> filterByObraAsig(String obraAsig) =>
+      _herramientas.where((h) => h.obraAsig == obraAsig).toList();
+
+  List<Herramienta> filterByCantidad(int cantidad) =>
+      _herramientas.where((h) => h.cantidad == cantidad).toList();
+
+  List<Herramienta> filterByGarantia(DateTime fechaLimite) =>
+      _herramientas.where((h) => h.garantia != null && h.garantia!.isBefore(fechaLimite)).toList();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -284,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
Lo mencioné en uno de los commits anteriores, pero por ahora el frontend de heramientas sale de 'Obras' en el menú home. Lo hice así ya que aún no tenemos implementado el menú interno de logística que está haciendo Carlos, y no puse que saliera directamente de 'Logística' porque como no soy el único que trabaja con eso, habrán conflictos con los merge en el futuro si lo hacía así.


De las cosas que hice está toda o casi toda la parte backend de heramientas y vehículos (modelos, endpoints, etc). Falta todavía ahí pero esto es progreso.
De front hice la vistta principal de herramientas, aunque es solo un inicio. Seguí la misma estructura que tiene la de trabajadores y ya se puede ver la lista de herramientas en el front, pero no mucho más.